### PR TITLE
Use Pod::UI for logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,9 @@ jobs:
           name: run tests
           command: |
             mkdir /tmp/test-results
-            bundle exec rspec spec/
+            bundle exec rspec --format RspecJunitFormatter \
+                              --out /tmp/test-results/rspec.xml \
+                              --format progress \
+                              spec/unit/
+      - store_test_results:
+          path: /tmp/test-results

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 
 group :development do
   gem 'rspec'
+  gem 'rspec_junit_formatter'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    rspec_junit_formatter (0.3.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     ruby-macho (1.1.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -90,6 +92,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods-mangle!
   rspec
+  rspec_junit_formatter
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/lib/cocoapods_mangle/builder.rb
+++ b/lib/cocoapods_mangle/builder.rb
@@ -1,3 +1,5 @@
+require 'cocoapods'
+
 module CocoapodsMangle
   class Builder
     BUILT_PRODUCTS_DIR = 'build/Release-iphonesimulator'
@@ -19,9 +21,11 @@ module CocoapodsMangle
     private
 
     def build_target(target)
+      Pod::UI.message "- Building '#{target}'"
       output = `xcodebuild -project "#{@pods_project.path}" -target "#{target}" -configuration Release -sdk iphonesimulator build 2>&1`
-      return true if $?.success?
-      raise "error: Building the Pods target '#{target}' failed.\ This is the build log:\n#{output}"
+      unless $?.success?
+        raise "error: Building the Pods target '#{target}' failed.\ This is the build log:\n#{output}"
+      end
     end
 
     def static_binaries_to_mangle

--- a/lib/cocoapods_mangle/hooks.rb
+++ b/lib/cocoapods_mangle/hooks.rb
@@ -6,10 +6,13 @@ module CocoapodsMangle
       xcconfig_path = CocoapodsMangle::Hooks.xcconfig_path(installer_context, options)
       pod_targets = CocoapodsMangle::Hooks.pod_targets(installer_context, options)
       mangle_prefix = CocoapodsMangle::Hooks.mangle_prefix(pod_targets, options)
-      CocoapodsMangle::PostInstall.new(xcconfig_path: xcconfig_path,
-                                       pod_targets: pod_targets,
-                                       pods_project: installer_context.pods_project,
-                                       mangle_prefix: mangle_prefix).run!
+      post_install = CocoapodsMangle::PostInstall.new(xcconfig_path: xcconfig_path,
+                                                      pod_targets: pod_targets,
+                                                      pods_project: installer_context.pods_project,
+                                                      mangle_prefix: mangle_prefix)
+      Pod::UI.titled_section 'Updating mangling' do
+        post_install.run!
+      end
     end
 
     def self.xcconfig_path(installer_context, options)

--- a/lib/cocoapods_mangle/post_install.rb
+++ b/lib/cocoapods_mangle/post_install.rb
@@ -1,4 +1,5 @@
 require 'digest'
+require 'cocoapods'
 require 'cocoapods_mangle/config'
 
 module CocoapodsMangle
@@ -11,12 +12,7 @@ module CocoapodsMangle
     end
 
     def run!
-      if config.needs_update?
-        puts 'Updating mangling config'
-        config.update_mangling!
-      else
-        puts 'Mangling config already up to date'
-      end
+      config.update_mangling! if config.needs_update?
       config.update_pod_xcconfigs_for_mangling!
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+require 'cocoapods'
+
+module Pod
+  # Overrides logging so it does not pollute the tests
+  #
+  module UI
+    class << self
+      def puts(message = '') end
+
+      def print(message) end
+    end
+  end
+end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,3 +1,4 @@
+require File.expand_path('../../spec_helper', __FILE__)
 require 'cocoapods_mangle/config'
 
 describe CocoapodsMangle::Config do
@@ -42,7 +43,7 @@ describe CocoapodsMangle::Config do
   end
 
   context '.needs_update?' do
-    let(:xcconfig_path) { "#{File.dirname(__FILE__)}/fixtures/mangle.xcconfig" }
+    let(:xcconfig_path) { "#{File.dirname(__FILE__)}/../fixtures/mangle.xcconfig" }
 
     context 'equal checksums' do
       let(:specs_checksum) { 'checksum' }

--- a/spec/unit/defines_spec.rb
+++ b/spec/unit/defines_spec.rb
@@ -1,11 +1,12 @@
+require File.expand_path('../../spec_helper', __FILE__)
 require 'cocoapods_mangle/defines'
 
 describe CocoapodsMangle::Defines do
   let(:non_global_defined_symbols) do
-    File.read("#{File.dirname(__FILE__)}/fixtures/non_global_defined_symbols.txt").split("\n")
+    File.read("#{File.dirname(__FILE__)}/../fixtures/non_global_defined_symbols.txt").split("\n")
   end
   let(:all_defined_symbols) do
-    File.read("#{File.dirname(__FILE__)}/fixtures/all_defined_symbols.txt").split("\n")
+    File.read("#{File.dirname(__FILE__)}/../fixtures/all_defined_symbols.txt").split("\n")
   end
   let(:defines) { CocoapodsMangle::Defines.mangling_defines('Prefix_', ['A.a', 'B.a']) }
 

--- a/spec/unit/hooks_spec.rb
+++ b/spec/unit/hooks_spec.rb
@@ -1,4 +1,4 @@
-require 'cocoapods'
+require File.expand_path('../../spec_helper', __FILE__)
 require 'cocoapods_mangle/hooks'
 
 def trigger_post_install(installer_context, options)

--- a/spec/unit/post_install_spec.rb
+++ b/spec/unit/post_install_spec.rb
@@ -1,5 +1,5 @@
+require File.expand_path('../../spec_helper', __FILE__)
 require 'cocoapods_mangle/post_install'
-require 'digest'
 
 describe CocoapodsMangle::PostInstall do
   let(:xcconfig_path) { 'path/to/mangle.xcconfig' }


### PR DESCRIPTION
Using `Pod::UI` for logging makes the output in `pod install` much easier to follow as well as allowing us to stop polluting unit tests.

`pod install --verbose` now gives output something like this:

```
...

Updating mangling
      - Updating mangling xcconfig
        - Building 'Pods-MyTarget'
        - Building 'Pods-MyOtherTarget'
        - Writing 'cocoapods-mangle.xcconfig'
      - Updating Pod xcconfig files
        - Updating 'AFNetworking.xcconfig'
        - Updating 'FLAnimatedImage.xcconfig'
        - Updating 'Pods-MyTarget.debug.xcconfig'
        - Updating 'Pods-MyTarget.release.xcconfig'
        - Updating 'Pods-MyOtherTarget.debug.xcconfig'
        - Updating 'Pods-MyOtherTarget.release.xcconfig'

...
```