### PR TITLE
Add CocoapodsMangle::Context to avoid passing hashes everywhere

### DIFF
--- a/lib/cocoapods_mangle/context.rb
+++ b/lib/cocoapods_mangle/context.rb
@@ -1,0 +1,72 @@
+module CocoapodsMangle
+  # Context for mangling
+  class Context
+    # @!attribute xcconfig_path
+    #   @return [String] The path to the mangle xcconfig
+    attr_accessor :xcconfig_path
+    # @!attribute mangle_prefix
+    #   @return [String] The mangle prefix to be used
+    attr_accessor :mangle_prefix
+    # @!attribute pods_project
+    #   @return [Pod::Project] The Pods Xcode project
+    attr_accessor :pods_project
+    # @!attribute umbrella_pod_targets
+    #   @return [Array<Pod::Installer::PostInstallHooksContext::UmbrellaTargetDescription>]
+    #           The umbrella targets to be mangled
+    attr_accessor :umbrella_pod_targets
+
+    # Initializes the context for mangling
+    # @param  [Pod::Installer::PostInstallHooksContext] installer_context
+    #         The post install context
+    # @param  [Hash] options
+    # @option options [String] :xcconfig_path
+    #                 The path to the mangling xcconfig
+    # @option options [String] :mangle_prefix
+    #                 The prefix to prepend to mangled symbols
+    # @option options [Array<String>] :targets
+    #                 The user targets whose dependencies should be mangled
+    def initialize(installer_context, options)
+      @xcconfig_path = build_xcconfig_path(installer_context, options[:xcconfig_path])
+      @pods_project = installer_context.pods_project
+      @umbrella_pod_targets = build_umbrella_pod_targets(installer_context, options[:targets])
+      @mangle_prefix = build_mangle_prefix(@umbrella_pod_targets, options[:mangle_prefix])
+    end
+
+    # @return [String] A checksum representing the current state of the target dependencies
+    def specs_checksum
+      gem_summary = "#{CocoapodsMangle::NAME}=#{CocoapodsMangle::VERSION}"
+      specs = @umbrella_pod_targets.map(&:specs).flatten.uniq
+      specs_summary = specs.map(&:checksum).join(',')
+      Digest::SHA1.hexdigest("#{gem_summary},#{specs_summary}")
+    end
+
+    private
+
+    def build_xcconfig_path(installer_context, user_xcconfig_path)
+      unless user_xcconfig_path
+        xcconfig_dir = installer_context.sandbox.target_support_files_root
+        xcconfig_filename = "#{CocoapodsMangle::NAME}.xcconfig"
+        return File.join(xcconfig_dir, xcconfig_filename)
+      end
+      File.join(installer_context.sandbox.root.parent, user_xcconfig_path)
+    end
+
+    def build_umbrella_pod_targets(installer_context, user_targets)
+      if user_targets.nil? || user_targets.empty?
+        return installer_context.umbrella_targets
+      end
+      installer_context.umbrella_targets.reject do |target|
+        target_names = target.user_targets.map(&:name)
+        (user_targets & target_names).empty?
+      end
+    end
+
+    def build_mangle_prefix(umbrella_pod_targets, user_mangle_prefix)
+      unless user_mangle_prefix
+        project_path = umbrella_pod_targets.first.user_project.path
+        return File.basename(project_path, '.xcodeproj') + '_'
+      end
+      user_mangle_prefix
+    end
+  end
+end

--- a/lib/cocoapods_mangle/hooks.rb
+++ b/lib/cocoapods_mangle/hooks.rb
@@ -1,65 +1,15 @@
+require 'cocoapods_mangle/context'
 require 'cocoapods_mangle/post_install'
 
 module CocoapodsMangle
   # Registers for CocoaPods plugin hooks
   module Hooks
     Pod::HooksManager.register(CocoapodsMangle::NAME, :post_install) do |installer_context, options|
-      xcconfig_path = CocoapodsMangle::Hooks.xcconfig_path(installer_context, options[:xcconfig_path])
-      umbrella_pod_targets = CocoapodsMangle::Hooks.umbrella_pod_targets(installer_context, options[:targets])
-      mangle_prefix = CocoapodsMangle::Hooks.mangle_prefix(umbrella_pod_targets, options[:mangle_prefix])
-      post_install = CocoapodsMangle::PostInstall.new(xcconfig_path: xcconfig_path,
-                                                      umbrella_pod_targets: umbrella_pod_targets,
-                                                      pods_project: installer_context.pods_project,
-                                                      mangle_prefix: mangle_prefix)
+      context = Context.new(installer_context, options)
+      post_install = CocoapodsMangle::PostInstall.new(context)
       Pod::UI.titled_section 'Updating mangling' do
         post_install.run!
       end
-    end
-
-    # Gets the mangle xcconfig path to use
-    # @param  [Pod::Installer::PostInstallHooksContext] installer_context
-    #         The post install context
-    # @param  [String] xcconfig_path
-    #         The mangle xcconfig path provided by the user
-    # @return The mangle xcconfig path to be used
-    def self.xcconfig_path(installer_context, user_xcconfig_path)
-      unless user_xcconfig_path
-        xcconfig_dir = installer_context.sandbox.target_support_files_root
-        xcconfig_filename = "#{CocoapodsMangle::NAME}.xcconfig"
-        return File.join(xcconfig_dir, xcconfig_filename)
-      end
-      File.join(installer_context.sandbox.root.parent, user_xcconfig_path)
-    end
-
-    # Gets the umbrella pod targets to mangle
-    # @param  [Pod::Installer::PostInstallHooksContext] installer_context
-    #         The post install context
-    # @param  [Array<String>] user_targets
-    #         The names of the user targets that should be mangled
-    # @return [Array<Pod::Installer::PostInstallHooksContext::UmbrellaTargetDescription>]
-    #         The pod umbrella targets to be mangled
-    def self.umbrella_pod_targets(installer_context, user_targets)
-      if user_targets.nil? || user_targets.empty?
-        return installer_context.umbrella_targets
-      end
-      installer_context.umbrella_targets.reject do |target|
-        target_names = target.user_targets.map(&:name)
-        (user_targets & target_names).empty?
-      end
-    end
-
-    # Gets the mangle prefix to be used
-    # @param  [Array<Pod::Installer::PostInstallHooksContext::UmbrellaTargetDescription>] umbrella_pod_targets
-    #         The umbrella pod targets that will be mangled
-    # @param  [String] user_mangle_prefix
-    #         The mangle prefix provided by the user
-    # @return The mangle prefix provided by the user
-    def self.mangle_prefix(umbrella_pod_targets, user_mangle_prefix)
-      unless user_mangle_prefix
-        project_path = umbrella_pod_targets.first.user_project.path
-        return File.basename(project_path, '.xcodeproj') + '_'
-      end
-      user_mangle_prefix
     end
   end
 end

--- a/lib/cocoapods_mangle/post_install.rb
+++ b/lib/cocoapods_mangle/post_install.rb
@@ -5,20 +5,9 @@ require 'cocoapods_mangle/config'
 module CocoapodsMangle
   # Runs the post mangling post install action
   class PostInstall
-    # @param [Hash] params the params for mangling.
-    # @option params [String] :xcconfig_path 
-    #                The path to the mangling xcconfig
-    # @option params [String] :mangle_prefix
-    #                The prefix to prepend to mangled symbols
-    # @option params [Pod::Project] :pods_project
-    #                The Pods Xcode project
-    # @option params [Array<Pod::Installer::PostInstallHooksContext::UmbrellaTargetDescription>] :umbrella_pod_targets
-    #                the umbrella pod targets whose dependencies should be mangled
-    def initialize(params)
-      @xcconfig_path = params[:xcconfig_path]
-      @mangle_prefix = params[:mangle_prefix]
-      @pods_project = params[:pods_project]
-      @umbrella_pod_targets = params[:umbrella_pod_targets]
+    # @param [CocoapodsMangle::Context] context The context for mangling.
+    def initialize(context)
+      @context = context
     end
 
     # Run the post install action
@@ -29,19 +18,7 @@ module CocoapodsMangle
 
     # @return [CocoapodsMangle::Config] The mangling config object
     def config
-      @config ||= CocoapodsMangle::Config.new(xcconfig_path: @xcconfig_path,
-                                              mangle_prefix: @mangle_prefix,
-                                              pods_project: @pods_project,
-                                              umbrella_pod_targets: @umbrella_pod_targets,
-                                              specs_checksum: specs_checksum)
-    end
-
-    # @return [String] A checksum representing the current state of the target dependencies
-    def specs_checksum
-      gem_summary = "#{CocoapodsMangle::NAME}=#{CocoapodsMangle::VERSION}"
-      specs = @umbrella_pod_targets.map(&:specs).flatten.uniq
-      specs_summary = specs.map(&:checksum).join(',')
-      Digest::SHA1.hexdigest("#{gem_summary},#{specs_summary}")
+      @config ||= CocoapodsMangle::Config.new(@context)
     end
   end
 end

--- a/spec/unit/context_spec.rb
+++ b/spec/unit/context_spec.rb
@@ -1,0 +1,77 @@
+require File.expand_path('../../spec_helper', __FILE__)
+require 'cocoapods_mangle/context'
+
+RSpec.shared_examples 'initializing context' do
+  it 'sets the correct values' do
+    context = CocoapodsMangle::Context.new(installer_context, options)
+    expect(context.xcconfig_path).to eq(xcconfig_path)
+    expect(context.umbrella_pod_targets).to eq(umbrella_pod_targets)
+    expect(context.pods_project).to eq(pods_project)
+    expect(context.mangle_prefix).to eq(mangle_prefix)
+  end
+end
+
+describe CocoapodsMangle::Context do
+  let(:umbrella_targets) do
+    [
+      instance_double('umbrella target A', cocoapods_target_label: 'Pods-A', user_targets: [instance_double('target A', name: 'A')]),
+      instance_double('umbrella target B', cocoapods_target_label: 'Pods-B', user_targets: [instance_double('target B', name: 'B')]),
+      instance_double('umbrella target C', cocoapods_target_label: 'Pods-C', user_targets: [instance_double('target C', name: 'C')])
+    ]
+  end
+  let(:installer_context) { instance_double('installer', pods_project: double('pods project'), umbrella_targets: umbrella_targets) }
+
+  before do
+    allow(installer_context).to receive_message_chain(:sandbox, :root, :parent).and_return( Pathname.new('/parent') )
+    allow(installer_context).to receive_message_chain(:sandbox, :target_support_files_root).and_return( Pathname.new('/support_files') )
+    allow(umbrella_targets.first).to receive_message_chain(:user_project, :path).and_return('path/to/Project.xcodeproj')
+  end
+
+  context 'Initialization' do
+    context 'all user defined options' do
+      let(:options) { { targets: ['A', 'B'], xcconfig_path: 'path/to/mangle.xcconfig', mangle_prefix: 'prefix_' } }
+      let(:xcconfig_path) { "/parent/#{options[:xcconfig_path]}" }
+      let(:umbrella_pod_targets) { umbrella_targets[0..1] }
+      let(:pods_project) { installer_context.pods_project }
+      let(:mangle_prefix) { options[:mangle_prefix] }
+
+      include_examples 'initializing context'
+    end
+
+    context 'only targets defined in options' do
+      let(:options) { { targets: ['A', 'B'] } }
+      let(:xcconfig_path) { "/support_files/#{CocoapodsMangle::NAME}.xcconfig" }
+      let(:umbrella_pod_targets) { umbrella_targets[0..1] }
+      let(:pods_project) { installer_context.pods_project }
+      let(:mangle_prefix) { 'Project_' }
+
+      include_examples 'initializing context'
+    end
+
+    context 'no options' do
+      let(:options) { {} }
+      let(:xcconfig_path) { "/support_files/#{CocoapodsMangle::NAME}.xcconfig" }
+      let(:umbrella_pod_targets) { umbrella_targets[0..2] }
+      let(:pods_project) { installer_context.pods_project }
+      let(:mangle_prefix) { 'Project_' }
+
+      include_examples 'initializing context'
+    end
+  end
+
+  context '.specs_checksum' do
+    let(:gem_summary) { "#{CocoapodsMangle::NAME}=#{CocoapodsMangle::VERSION}" }
+    let(:spec_A) { instance_double('Spec A', checksum: 'checksum_A') }
+    let(:spec_B) { instance_double('Spec B', checksum: 'checksum_B') }
+    let(:subject) { CocoapodsMangle::Context.new(installer_context, targets: ['A']) }
+
+    before do
+      allow(umbrella_targets.first).to receive(:specs).and_return([spec_A, spec_B])
+    end
+
+    it 'gives the checksum' do
+      summary = "#{gem_summary},checksum_A,checksum_B"
+      expect(subject.specs_checksum).to eq(Digest::SHA1.hexdigest(summary))
+    end
+  end
+end

--- a/spec/unit/hooks_spec.rb
+++ b/spec/unit/hooks_spec.rb
@@ -7,75 +7,22 @@ def trigger_post_install(installer_context, options)
   hook.block.call(installer_context, options)
 end
 
-RSpec.shared_examples 'post install hook' do
-  it 'passes the correct options' do
-    expect(CocoapodsMangle::PostInstall).to receive(:new).with(post_install_options)
-    expect(post_install).to receive(:run!)
-
-    trigger_post_install(installer_context, options)
-  end
-end
-
 describe CocoapodsMangle::Hooks do
-  let(:umbrella_targets) do
-    [
-      instance_double('umbrella target A', cocoapods_target_label: 'Pods-A', user_targets: [instance_double('target A', name: 'A')]),
-      instance_double('umbrella target B', cocoapods_target_label: 'Pods-B', user_targets: [instance_double('target B', name: 'B')]),
-      instance_double('umbrella target C', cocoapods_target_label: 'Pods-C', user_targets: [instance_double('target C', name: 'C')])
-    ]
-  end
-  let(:installer_context) { instance_double('installer', pods_project: double('pods project'), umbrella_targets: umbrella_targets) }
+  let(:installer_context) { instance_double('installer context') }
+  let(:options) { double('options') }
+  let(:mangle_context) { instance_double('installer context') }
   let(:post_install) { double('post install') }
-  let(:options) { {} }
-  let(:post_install_options) { {} }
 
   before do
-    allow(installer_context).to receive_message_chain(:sandbox, :root, :parent).and_return( Pathname.new('/parent') )
-    allow(installer_context).to receive_message_chain(:sandbox, :target_support_files_root).and_return( Pathname.new('/support_files') )
-    allow(umbrella_targets.first).to receive_message_chain(:user_project, :path).and_return('path/to/Project.xcodeproj')
-    allow(CocoapodsMangle::PostInstall).to receive(:new).with(post_install_options).and_return(post_install)
+    allow(CocoapodsMangle::Context).to receive(:new).with(installer_context, options).and_return(mangle_context)
+    allow(CocoapodsMangle::PostInstall).to receive(:new).with(mangle_context).and_return(post_install)
     allow(post_install).to receive(:run!)
   end
 
-  context 'all user defined options' do
-    let(:options) { { targets: ['A', 'B'], xcconfig_path: 'path/to/mangle.xcconfig', mangle_prefix: 'prefix_' } }
-    let(:post_install_options) do
-      {
-        xcconfig_path: "/parent/#{options[:xcconfig_path]}",
-        umbrella_pod_targets: umbrella_targets[0..1],
-        pods_project: installer_context.pods_project,
-        mangle_prefix: options[:mangle_prefix]
-      }
+  context 'post install' do
+    it 'runs the post install action' do
+      expect(post_install).to receive(:run!)
+      trigger_post_install(installer_context, options)
     end
-
-    include_examples 'post install hook'
-  end
-
-  context 'only targets defined in options' do
-    let(:options) { { targets: ['A', 'B'] } }
-    let(:post_install_options) do
-      {
-        xcconfig_path: "/support_files/#{CocoapodsMangle::NAME}.xcconfig",
-        umbrella_pod_targets: umbrella_targets[0..1],
-        pods_project: installer_context.pods_project,
-        mangle_prefix: 'Project_'
-      }
-    end
-
-    include_examples 'post install hook'
-  end
-
-  context 'no options' do
-    let(:options) { {} }
-    let(:post_install_options) do
-      {
-        xcconfig_path: "/support_files/#{CocoapodsMangle::NAME}.xcconfig",
-        umbrella_pod_targets: umbrella_targets,
-        pods_project: installer_context.pods_project,
-        mangle_prefix: 'Project_'
-      }
-    end
-
-    include_examples 'post install hook'
   end
 end

--- a/spec/unit/post_install_spec.rb
+++ b/spec/unit/post_install_spec.rb
@@ -2,24 +2,20 @@ require File.expand_path('../../spec_helper', __FILE__)
 require 'cocoapods_mangle/post_install'
 
 describe CocoapodsMangle::PostInstall do
-  let(:xcconfig_path) { 'path/to/mangle.xcconfig' }
-  let(:umbrella_pod_targets) { [instance_double('target', cocoapods_target_label: 'Pods-A')] }
-  let(:pods_project) { double('pods project') }
-  let(:mangle_prefix) { 'prefix_' }
-  let(:subject) do
-    CocoapodsMangle::PostInstall.new(xcconfig_path: xcconfig_path,
-                                     umbrella_pod_targets: umbrella_pod_targets,
-                                     pods_project: pods_project,
-                                     mangle_prefix: mangle_prefix)
+  let(:context) do 
+    instance_double('Mangle context')
   end
+  let(:subject) do
+    CocoapodsMangle::PostInstall.new(context)
+  end
+  let(:config) { double('config') }
 
   context '.run!' do
-    let(:config) { double('config') }
     let(:specs_checksum) { 'checksum' }
 
     before do
       allow(subject).to receive(:config).and_return(config)
-      allow(subject).to receive(:specs_checksum).and_return(specs_checksum)
+      allow(context).to receive(:specs_checksum).and_return(specs_checksum)
     end
 
     it 'updates mangling and pod xcconfigs' do
@@ -44,30 +40,12 @@ describe CocoapodsMangle::PostInstall do
 
     before do
       allow(subject).to receive(:specs_checksum).and_return(specs_checksum)
+      allow(CocoapodsMangle::Config).to receive(:new).with(context).and_return(config)
     end
 
     it 'creates a config' do
-      expect(CocoapodsMangle::Config).to receive(:new).with(xcconfig_path: xcconfig_path,
-                                                            mangle_prefix: mangle_prefix,
-                                                            pods_project: pods_project,
-                                                            umbrella_pod_targets: umbrella_pod_targets,
-                                                            specs_checksum: specs_checksum).and_call_original
-      expect(subject.config).to be_a CocoapodsMangle::Config
-    end
-  end
-
-  context '.specs_checksum' do
-    let(:gem_summary) { "#{CocoapodsMangle::NAME}=#{CocoapodsMangle::VERSION}" }
-    let(:spec_A) { instance_double('Spec A', checksum: 'checksum_A') }
-    let(:spec_B) { instance_double('Spec B', checksum: 'checksum_B') }
-
-    before do
-      allow(umbrella_pod_targets.first).to receive(:specs).and_return([spec_A, spec_B])
-    end
-
-    it 'gives the checksum' do
-      summary = "#{gem_summary},checksum_A,checksum_B"
-      expect(subject.specs_checksum).to eq(Digest::SHA1.hexdigest(summary))
+      expect(CocoapodsMangle::Config).to receive(:new).with(context)
+      expect(subject.config).to eq(config)
     end
   end
 end


### PR DESCRIPTION
Passing a big hash everywhere was getting messy. This just adds a class that holds the needed context.

There are no functional changes.