### PR TITLE
Encapsulate PostInstallHooksContext within CocoapodsMangle::Context

### DIFF
--- a/lib/cocoapods_mangle/builder.rb
+++ b/lib/cocoapods_mangle/builder.rb
@@ -7,20 +7,20 @@ module CocoapodsMangle
   class Builder
     BUILT_PRODUCTS_DIR = 'build/Release-iphonesimulator'
 
-    # @param    [Pod::Project] pods_project
-    #           the pods project to build.
+    # @param    [String] pods_project_path
+    #           path to the pods project to build.
     #
-    # @param    [Array<Pod::Installer::PostInstallHooksContext::UmbrellaTargetDescription>] umbrella_pod_targets
-    #           the umbrella pod targets to build.
-    def initialize(pods_project, umbrella_pod_targets)
-      @pods_project = pods_project
-      @umbrella_pod_targets = umbrella_pod_targets
+    # @param    [Array<String>] pod_target_labels
+    #           the pod targets to build.
+    def initialize(pods_project_path, pod_target_labels)
+      @pods_project_path = pods_project_path
+      @pod_target_labels = pod_target_labels
     end
 
     # Build the pods project
     def build!
       FileUtils.remove_dir(BUILT_PRODUCTS_DIR, true)
-      @umbrella_pod_targets.each { |target| build_target(target.cocoapods_target_label) }
+      @pod_target_labels.each { |target| build_target(target) }
     end
 
     # Gives the built binaries to be mangled
@@ -33,7 +33,7 @@ module CocoapodsMangle
 
     def build_target(target)
       Pod::UI.message "- Building '#{target}'"
-      output = `xcodebuild -project "#{@pods_project.path}" -target "#{target}" -configuration Release -sdk iphonesimulator build 2>&1`
+      output = `xcodebuild -project "#{@pods_project_path}" -target "#{target}" -configuration Release -sdk iphonesimulator build 2>&1`
       unless $?.success?
         raise "error: Building the Pods target '#{target}' failed.\ This is the build log:\n#{output}"
       end

--- a/lib/cocoapods_mangle/config.rb
+++ b/lib/cocoapods_mangle/config.rb
@@ -17,7 +17,7 @@ module CocoapodsMangle
     # Update the mangling xcconfig file with new mangling defines
     def update_mangling!
       Pod::UI.message '- Updating mangling xcconfig' do
-        builder = Builder.new(@context.pods_project, @context.umbrella_pod_targets)
+        builder = Builder.new(@context.pods_project_path, @context.pod_target_labels)
         builder.build!
 
         defines = Defines.mangling_defines(@context.mangle_prefix, builder.binaries_to_mangle)
@@ -49,16 +49,8 @@ module CocoapodsMangle
 
     # Update all pod xcconfigs to use the mangling defines
     def update_pod_xcconfigs_for_mangling!
-      pod_xcconfigs = Set.new
-
-      @context.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-          pod_xcconfigs.add(config.base_configuration_reference.real_path)
-        end
-      end
-
-      Pod::UI.message "- Updating Pod xcconfig files" do
-        pod_xcconfigs.each do |pod_xcconfig_path|
+      Pod::UI.message '- Updating Pod xcconfig files' do
+        @context.pod_xcconfig_paths.each do |pod_xcconfig_path|
           Pod::UI.message "- Updating '#{File.basename(pod_xcconfig_path)}'"
           update_pod_xcconfig_for_mangling!(pod_xcconfig_path)
         end

--- a/lib/cocoapods_mangle/post_install.rb
+++ b/lib/cocoapods_mangle/post_install.rb
@@ -1,4 +1,3 @@
-require 'digest'
 require 'cocoapods'
 require 'cocoapods_mangle/config'
 


### PR DESCRIPTION
This simplifies the implementation by limiting usage of the CocoaPods plugin API to just one place. This should help with maintenance going forward.