### PR TITLE
Remove Additional Swift Symbols

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cocoapods-mangle (1.1.1)
+    cocoapods-mangle (1.1.2)
       cocoapods (~> 1.11.3)
 
 GEM
@@ -15,7 +15,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.2)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)

--- a/cocoapods-mangle.gemspec
+++ b/cocoapods-mangle.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.license     = 'Apache-2.0'
   spec.email       = ['james@intercom.io']
   spec.homepage    = 'https://github.com/intercom/cocoapods-mangle'
-  spec.authors     = ['James Treanor']
+  spec.authors     = ['James Treanor, Brian Boyle']
   spec.summary     = 'A CocoaPods plugin which mangles ' \
                      'the symbols of your dependencies'
   spec.description = 'Mangling your dependencies symbols allows more than '    \

--- a/lib/cocoapods_mangle/defines.rb
+++ b/lib/cocoapods_mangle/defines.rb
@@ -154,7 +154,10 @@ module CocoapodsMangle
         symbol[/_\w+_swiftoverride_/] ||
         # _Zxxxswift symbols should be skipped
         # e.g. _ZN5swift34swift50override_conformsToProtocolEPKNS
-        symbol[/_Z\w+swift/]
+        symbol[/_Z\w+swift/] ||
+        # get_witness_table symbols should be skipped
+        # e.g. get_witness_table Say6.2
+        symbol[/get_witness_table /]
     end
 
     def self.run_nm(binaries, flags)

--- a/lib/cocoapods_mangle/gem_version.rb
+++ b/lib/cocoapods_mangle/gem_version.rb
@@ -1,4 +1,4 @@
 module CocoapodsMangle
   NAME = 'cocoapods-mangle'
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end


### PR DESCRIPTION
- Ensure that we don't mangle Swift symbols matching the pattern `get_witness_table `
- Bumped version to `1.1.2`