### PR TITLE
Route CI gem installs through Socket Firewall registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,17 @@ jobs:
           - macos-dependencies-{{ checksum "Gemfile.lock" }}
           - macos-dependencies-
       - run:
+          name: Configure Bundler to use Socket Firewall registry
+          command: |
+            bundle config set --global mirror.https://rubygems.org https://socket-firewall-registry.corporate.intercom.io/rubygems
+            bundle config set --global https://socket-firewall-registry.corporate.intercom.io/rubygems "intercom-socket:${SOCKET_REGISTRY_TOKEN}"
+      - run:
+          name: Verify Socket Firewall mirror is active
+          command: |
+            MIRROR=$(bundle config mirror.https://rubygems.org | grep -o 'https://.*')
+            echo "Bundler mirror: $MIRROR"
+            echo "$MIRROR" | grep -q socket-firewall-registry || { echo "FAIL: Socket mirror not configured"; exit 1; }
+      - run:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
@@ -35,3 +46,11 @@ jobs:
                               spec/
       - store_test_results:
           path: /tmp/test-results
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          context:
+            - socket-firewall


### PR DESCRIPTION
### Why?

Part of a CI supply-chain hardening effort: dependency installs should be scanned by Socket Firewall before they're fetched. This repo's CI installed gems directly from rubygems.org with no such scanning.

### How?

Mirrors rubygems.org through the Socket Firewall registry before `bundle install`, with the registry token injected at runtime via the `socket-firewall` CircleCI context — no credential committed — plus a verify step that fails the build if the mirror isn't active.

<sub>Generated with Claude Code</sub>